### PR TITLE
feat: integrate cli with extension to generate stub file

### DIFF
--- a/pyo3-intellisense/src/executor.ts
+++ b/pyo3-intellisense/src/executor.ts
@@ -2,6 +2,7 @@ import * as vscode from 'vscode';
 import * as fs from 'fs';
 import * as path from 'path';
 import * as toml from 'toml';
+import { execFile } from 'child_process';
 
 export function isPyo3Project(): boolean {
     const folders = vscode.workspace.workspaceFolders;
@@ -22,4 +23,20 @@ export function isPyo3Project(): boolean {
         }
     }
     return false;
+}
+
+export function getCliBinaryPath(context: vscode.ExtensionContext): string {
+    return path.join(context.extensionPath, 'bin', 'pryo3-stubs-cli-macos');
+}
+
+export function runCli(context: vscode.ExtensionContext, libPath: string) {
+    const cliPath = getCliBinaryPath(context);
+    const outputPath = path.join(path.dirname(libPath), 'stubs.pyi');
+    execFile(cliPath, ['--input', libPath, '--output', outputPath], (error, stdout, stderr) => {
+        if (error) {
+            vscode.window.showErrorMessage(`Stub generation failed: ${stderr || error.message}`);
+        } else {
+            vscode.window.showInformationMessage('Stub generation succeeded!');
+        }
+    });
 }

--- a/pyo3-intellisense/src/extension.ts
+++ b/pyo3-intellisense/src/extension.ts
@@ -1,5 +1,5 @@
 import * as vscode from 'vscode';
-import { isPyo3Project } from './executor';
+import { isPyo3Project, runCli } from './executor';
 
 export function activate(context: vscode.ExtensionContext) {
 	console.log('Congratulations, your extension "pyo3-intellisense" is now active!');
@@ -9,9 +9,11 @@ export function activate(context: vscode.ExtensionContext) {
 
 		if (isPyo3Project()) {
 			const watcher = vscode.workspace.createFileSystemWatcher('**/src/lib.rs');
+
 			watcher.onDidChange(uri => {
 				vscode.window.showInformationMessage(`Rust file changed: ${uri.fsPath}`);
-			});
+				runCli(context, uri.fsPath);
+			}); 
 		} else {
 			vscode.window.showErrorMessage('Not a Pyo3/maturin project.');
 		}


### PR DESCRIPTION
### Summary
This PR integrates the rust cli with the extension to generate stub files.

### Key Changes
- Place the cli binary under `pyo3-intellisense/bin/` 
- Add functionality to get the cli binary path and use it by passing appropriate arguments.
- Update `.gitignore` to ignore `pyo3-intellisense/bin/`